### PR TITLE
Replaced firstChild with children[0] in findParent.

### DIFF
--- a/src/svgLines.js
+++ b/src/svgLines.js
@@ -23,7 +23,7 @@ function findParent(node) {
     if (!parentRow) {
         return null;
     }
-    return parentRow.firstChild.firstChild;
+    return parentRow.children[0].children[0];
 }
 
 /**


### PR DESCRIPTION
This will ensure that the first node will be returnd unlike FirstChild which searches text+nodes.